### PR TITLE
Add pagination to all index function

### DIFF
--- a/lib/dbservice_web/controllers/batch_controller.ex
+++ b/lib/dbservice_web/controllers/batch_controller.ex
@@ -23,18 +23,22 @@ defmodule DbserviceWeb.BatchController do
   end
 
   def index(conn, params) do
-    param = Enum.map(params, fn {key, value} -> {String.to_existing_atom(key), value} end)
+    query =
+      from m in Batch,
+        order_by: [asc: m.id],
+        offset: ^params["offset"],
+        limit: ^params["limit"]
 
-    batch =
-      Enum.reduce(param, Batch, fn
-        {key, value}, query ->
-          from u in query, where: field(u, ^key) == ^value
-
-        _, query ->
-          query
+    query =
+      Enum.reduce(params, query, fn {key, value}, acc ->
+        case String.to_existing_atom(key) do
+          :offset -> acc
+          :limit -> acc
+          atom -> from u in acc, where: field(u, ^atom) == ^value
+        end
       end)
-      |> Repo.all()
 
+    batch = Repo.all(query)
     render(conn, "index.json", batch: batch)
   end
 

--- a/lib/dbservice_web/controllers/batch_program_controller.ex
+++ b/lib/dbservice_web/controllers/batch_program_controller.ex
@@ -26,18 +26,22 @@ defmodule DbserviceWeb.BatchProgramController do
   end
 
   def index(conn, params) do
-    param = Enum.map(params, fn {key, value} -> {String.to_existing_atom(key), value} end)
+    query =
+      from m in BatchProgram,
+        order_by: [asc: m.id],
+        offset: ^params["offset"],
+        limit: ^params["limit"]
 
-    batch_program =
-      Enum.reduce(param, BatchProgram, fn
-        {key, value}, query ->
-          from u in query, where: field(u, ^key) == ^value
-
-        _, query ->
-          query
+    query =
+      Enum.reduce(params, query, fn {key, value}, acc ->
+        case String.to_existing_atom(key) do
+          :offset -> acc
+          :limit -> acc
+          atom -> from u in acc, where: field(u, ^atom) == ^value
+        end
       end)
-      |> Repo.all()
 
+    batch_program = Repo.all(query)
     render(conn, "index.json", batch_program: batch_program)
   end
 

--- a/lib/dbservice_web/controllers/enrollment_record_controller.ex
+++ b/lib/dbservice_web/controllers/enrollment_record_controller.ex
@@ -25,18 +25,22 @@ defmodule DbserviceWeb.EnrollmentRecordController do
   end
 
   def index(conn, params) do
-    param = Enum.map(params, fn {key, value} -> {String.to_existing_atom(key), value} end)
+    query =
+      from m in EnrollmentRecord,
+        order_by: [asc: m.id],
+        offset: ^params["offset"],
+        limit: ^params["limit"]
 
-    enrollment_record =
-      Enum.reduce(param, EnrollmentRecord, fn
-        {key, value}, query ->
-          from u in query, where: field(u, ^key) == ^value
-
-        _, query ->
-          query
+    query =
+      Enum.reduce(params, query, fn {key, value}, acc ->
+        case String.to_existing_atom(key) do
+          :offset -> acc
+          :limit -> acc
+          atom -> from u in acc, where: field(u, ^atom) == ^value
+        end
       end)
-      |> Repo.all()
 
+    enrollment_record = Repo.all(query)
     render(conn, "index.json", enrollment_record: enrollment_record)
   end
 

--- a/lib/dbservice_web/controllers/group_controller.ex
+++ b/lib/dbservice_web/controllers/group_controller.ex
@@ -23,18 +23,22 @@ defmodule DbserviceWeb.GroupController do
   end
 
   def index(conn, params) do
-    param = Enum.map(params, fn {key, value} -> {String.to_existing_atom(key), value} end)
+    query =
+      from m in Group,
+        order_by: [asc: m.id],
+        offset: ^params["offset"],
+        limit: ^params["limit"]
 
-    group =
-      Enum.reduce(param, Group, fn
-        {key, value}, query ->
-          from u in query, where: field(u, ^key) == ^value
-
-        _, query ->
-          query
+    query =
+      Enum.reduce(params, query, fn {key, value}, acc ->
+        case String.to_existing_atom(key) do
+          :offset -> acc
+          :limit -> acc
+          atom -> from u in acc, where: field(u, ^atom) == ^value
+        end
       end)
-      |> Repo.all()
 
+    group = Repo.all(query)
     render(conn, "index.json", group: group)
   end
 

--- a/lib/dbservice_web/controllers/group_type_controller.ex
+++ b/lib/dbservice_web/controllers/group_type_controller.ex
@@ -35,18 +35,22 @@ defmodule DbserviceWeb.GroupTypeController do
 
   @spec index(Plug.Conn.t(), any) :: Plug.Conn.t()
   def index(conn, params) do
-    param = Enum.map(params, fn {key, value} -> {String.to_existing_atom(key), value} end)
+    query =
+      from m in GroupType,
+        order_by: [asc: m.id],
+        offset: ^params["offset"],
+        limit: ^params["limit"]
 
-    group_type =
-      Enum.reduce(param, GroupType, fn
-        {key, value}, query ->
-          from u in query, where: field(u, ^key) == ^value
-
-        _, query ->
-          query
+    query =
+      Enum.reduce(params, query, fn {key, value}, acc ->
+        case String.to_existing_atom(key) do
+          :offset -> acc
+          :limit -> acc
+          atom -> from u in acc, where: field(u, ^atom) == ^value
+        end
       end)
-      |> Repo.all()
 
+    group_type = Repo.all(query)
     render(conn, "index.json", group_type: group_type)
   end
 

--- a/lib/dbservice_web/controllers/program_controller.ex
+++ b/lib/dbservice_web/controllers/program_controller.ex
@@ -23,18 +23,22 @@ defmodule DbserviceWeb.ProgramController do
   end
 
   def index(conn, params) do
-    param = Enum.map(params, fn {key, value} -> {String.to_existing_atom(key), value} end)
+    query =
+      from m in Program,
+        order_by: [asc: m.id],
+        offset: ^params["offset"],
+        limit: ^params["limit"]
 
-    program =
-      Enum.reduce(param, Program, fn
-        {key, value}, query ->
-          from u in query, where: field(u, ^key) == ^value
-
-        _, query ->
-          query
+    query =
+      Enum.reduce(params, query, fn {key, value}, acc ->
+        case String.to_existing_atom(key) do
+          :offset -> acc
+          :limit -> acc
+          atom -> from u in acc, where: field(u, ^atom) == ^value
+        end
       end)
-      |> Repo.all()
 
+    program = Repo.all(query)
     render(conn, "index.json", program: program)
   end
 

--- a/lib/dbservice_web/controllers/session_controller.ex
+++ b/lib/dbservice_web/controllers/session_controller.ex
@@ -30,18 +30,22 @@ defmodule DbserviceWeb.SessionController do
   end
 
   def index(conn, params) do
-    param = Enum.map(params, fn {key, value} -> {String.to_existing_atom(key), value} end)
+    query =
+      from m in Session,
+        order_by: [asc: m.id],
+        offset: ^params["offset"],
+        limit: ^params["limit"]
 
-    session =
-      Enum.reduce(param, Session, fn
-        {key, value}, query ->
-          from u in query, where: field(u, ^key) == ^value
-
-        _, query ->
-          query
+    query =
+      Enum.reduce(params, query, fn {key, value}, acc ->
+        case String.to_existing_atom(key) do
+          :offset -> acc
+          :limit -> acc
+          atom -> from u in acc, where: field(u, ^atom) == ^value
+        end
       end)
-      |> Repo.all()
 
+    session = Repo.all(query)
     render(conn, "index.json", session: session)
   end
 

--- a/lib/dbservice_web/controllers/session_occurence_controller.ex
+++ b/lib/dbservice_web/controllers/session_occurence_controller.ex
@@ -29,18 +29,22 @@ defmodule DbserviceWeb.SessionOccurenceController do
   end
 
   def index(conn, params) do
-    param = Enum.map(params, fn {key, value} -> {String.to_existing_atom(key), value} end)
+    query =
+      from m in SessionOccurence,
+        order_by: [asc: m.id],
+        offset: ^params["offset"],
+        limit: ^params["limit"]
 
-    session_occurence =
-      Enum.reduce(param, SessionOccurence, fn
-        {key, value}, query ->
-          from u in query, where: field(u, ^key) == ^value
-
-        _, query ->
-          query
+    query =
+      Enum.reduce(params, query, fn {key, value}, acc ->
+        case String.to_existing_atom(key) do
+          :offset -> acc
+          :limit -> acc
+          atom -> from u in acc, where: field(u, ^atom) == ^value
+        end
       end)
-      |> Repo.all()
 
+    session_occurence = Repo.all(query)
     render(conn, "index.json", session_occurence: session_occurence)
   end
 

--- a/lib/dbservice_web/controllers/teacher_controller.ex
+++ b/lib/dbservice_web/controllers/teacher_controller.ex
@@ -46,7 +46,7 @@ defmodule DbserviceWeb.TeacherController do
         end
       end)
 
-    teacher = Repo.all(query)
+    teacher = Repo.all(query) |> Repo.preload([:user])
     render(conn, "index.json", teacher: teacher)
   end
 

--- a/lib/dbservice_web/controllers/teacher_controller.ex
+++ b/lib/dbservice_web/controllers/teacher_controller.ex
@@ -31,20 +31,23 @@ defmodule DbserviceWeb.TeacherController do
   end
 
   def index(conn, params) do
-    param = Enum.map(params, fn {key, value} -> {String.to_existing_atom(key), value} end)
+    query =
+      from m in Teacher,
+        order_by: [asc: m.id],
+        offset: ^params["offset"],
+        limit: ^params["limit"]
 
-    teacher =
-      Enum.reduce(param, Teacher, fn
-        {key, value}, query ->
-          from u in query, where: field(u, ^key) == ^value
-
-        _, query ->
-          query
+    query =
+      Enum.reduce(params, query, fn {key, value}, acc ->
+        case String.to_existing_atom(key) do
+          :offset -> acc
+          :limit -> acc
+          atom -> from u in acc, where: field(u, ^atom) == ^value
+        end
       end)
-      |> Repo.all()
-      |> Repo.preload([:user])
 
-    render(conn, "show_with_user.json", teacher: teacher)
+    teacher = Repo.all(query)
+    render(conn, "index.json", teacher: teacher)
   end
 
   swagger_path :create do

--- a/lib/dbservice_web/controllers/user_session_controller.ex
+++ b/lib/dbservice_web/controllers/user_session_controller.ex
@@ -25,18 +25,22 @@ defmodule DbserviceWeb.UserSessionController do
   end
 
   def index(conn, params) do
-    param = Enum.map(params, fn {key, value} -> {String.to_existing_atom(key), value} end)
+    query =
+      from m in UserSession,
+        order_by: [asc: m.id],
+        offset: ^params["offset"],
+        limit: ^params["limit"]
 
-    user_session =
-      Enum.reduce(param, UserSession, fn
-        {key, value}, query ->
-          from u in query, where: field(u, ^key) == ^value
-
-        _, query ->
-          query
+    query =
+      Enum.reduce(params, query, fn {key, value}, acc ->
+        case String.to_existing_atom(key) do
+          :offset -> acc
+          :limit -> acc
+          atom -> from u in acc, where: field(u, ^atom) == ^value
+        end
       end)
-      |> Repo.all()
 
+    user_session = Repo.all(query)
     render(conn, "index.json", user_session: user_session)
   end
 

--- a/lib/dbservice_web/views/group_session_view.ex
+++ b/lib/dbservice_web/views/group_session_view.ex
@@ -13,7 +13,7 @@ defmodule DbserviceWeb.GroupSessionView do
   def render("group_session.json", %{group_session: group_session}) do
     %{
       id: group_session.id,
-      group_id: group_session.group_id,
+      group_type_id: group_session.group_type_id,
       session_id: group_session.session_id
     }
   end


### PR DESCRIPTION
This pull request adds pagination to the index function in all controller. The offset and limit parameters are now used to control which subset of records is returned by the Ecto query, allowing clients to easily paginate through large result sets.

In addition, the function has been refactored to simplify the parameter handling and improve readability.