### PR TITLE
Update session controller to enable pagination

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ erl_crash.dump
 # Ignore package tarball (built via "mix hex.build").
 dbservice-*.tar
 
+# Ignore .env file
+/config/.env
+

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -15,8 +15,18 @@ Install the following packages using your favorite package manager. Links are pr
     ```
 
 - [Install Postgres](https://www.postgresql.org/download/)
+  - Run the following steps to install Postgres on a Mac device
+    ```
+    brew install postgresql
+    brew services start postgresql
+    ```
+  - Once installed, verify the installations using `postgres --version`. You should be able to see:
+    ```
+    postgres (PostgreSQL) 14.9 (Homebrew)
+    ```
   - For Postgres, this app defaults to `postgres` as both the username and password. This can be edited in `config/dev.exs` file.
-  - Create a new database for the application called `dbservice_dev`.
+  - Create a new database for the application called `dbservice_dev`. You can do this by running the command: `createdb dbservice_dev`
+  - You can also use interactive postgres terminal `psql`. To open database, use: `psql -d dbservice_dev`
   - Log into the database created.
   - Open the Postgres CLI and check the enabled extensions:
 
@@ -37,8 +47,8 @@ Follow the steps below to set up the repo for development
 1. Clone the repository and change the working directory
 
     ```sh
-    git clone https://github.com/avantifellows/db-service-backend.git
-    cd db-service-backend/
+    git clone https://github.com/avantifellows/db-service.git
+    cd db-service/
     ```
 
 2. Start the Phoenix server:
@@ -46,13 +56,17 @@ Follow the steps below to set up the repo for development
    2. Create and migrate your database with `mix ecto.setup`
    3. Start Phoenix endpoint with `mix phx.server` or inside IEx with `iex -S mix phx.server`
 3. Now you can visit [`localhost:4000`](http://localhost:4000) from your browser.
+4. You can see Swagger docs at `http://localhost:4000/docs/swagger/index.html`.
+5. Please verify that `localhost` is part of whitelisted domains. If not, you can create a file `db-service/config/.env` and add the following lines to it:
+    ```
+    WHITELISTED_DOMAINS="localhost"
+    ```
 
-### Seeding fake data (optional)
+### Adding data to local database
 
-If you want to seed your local database with random fake data, you can run this command:
-
-```sh
-mix run priv/repo/seeds.exs
+You can add data to local database by running `sh ./fetch-data.sh`. This will fetch data from production/staging database and sync with your local database. Please ask repository owners for the following credentials:
+```production_db_host="xxx.rds.amazonaws.com"
+production_db_name="xxx"
+production_db_user="postgres"
+production_db_password="xxx"
 ```
-
-If you want to modify how this random fake data is getting seeded, you can modify this file `priv/repo/seeds.exs`.

--- a/lib/dbservice_web/controllers/session_controller.ex
+++ b/lib/dbservice_web/controllers/session_controller.ex
@@ -52,22 +52,21 @@ defmodule DbserviceWeb.SessionController do
 
     query =
       Enum.reduce(params, query, fn {key, value}, acc ->
-        case key do
-          "offset" ->
+        case String.to_existing_atom(key) do
+          :offset ->
             acc
 
-          "limit" ->
+          :limit ->
             acc
 
-          "sort_order" ->
+          :sort_order ->
             acc
 
-          "session_id_is_null" ->
+          :session_id_is_null ->
             apply_session_id_null_filter(value, acc)
 
-          _ ->
-            field_name = String.to_existing_atom(key)
-            from u in acc, where: field(u, ^field_name) == ^value
+          atom ->
+            from(u in acc, where: field(u, ^atom) == ^value)
         end
       end)
 

--- a/lib/dbservice_web/controllers/session_controller.ex
+++ b/lib/dbservice_web/controllers/session_controller.ex
@@ -51,12 +51,18 @@ defmodule DbserviceWeb.SessionController do
     query =
       Enum.reduce(params, query, fn {key, value}, acc ->
         case String.to_existing_atom(key) do
-          :offset -> acc
-          :limit -> acc
+          :offset ->
+            acc
+
+          :limit ->
+            acc
+
           :session_id_is_null when value == "true" ->
             # filter for session_id being null
             from u in acc, where: is_nil(u.session_id)
-          atom -> from u in acc, where: field(u, ^atom) == ^value
+
+          atom ->
+            from u in acc, where: field(u, ^atom) == ^value
         end
       end)
 

--- a/lib/dbservice_web/controllers/session_controller.ex
+++ b/lib/dbservice_web/controllers/session_controller.ex
@@ -44,7 +44,7 @@ defmodule DbserviceWeb.SessionController do
   def index(conn, params) do
     query =
       from m in Session,
-        order_by: [asc: m.id],
+        order_by: [desc: m.id],
         offset: ^params["offset"],
         limit: ^params["limit"]
 

--- a/lib/dbservice_web/controllers/session_controller.ex
+++ b/lib/dbservice_web/controllers/session_controller.ex
@@ -66,7 +66,8 @@ defmodule DbserviceWeb.SessionController do
             apply_session_id_null_filter(value, acc)
 
           _ ->
-            from u in acc, where: field(u, ^key) == ^value
+            field_name = String.to_existing_atom(key)
+            from u in acc, where: field(u, ^field_name) == ^value
         end
       end)
 

--- a/lib/dbservice_web/controllers/session_controller.ex
+++ b/lib/dbservice_web/controllers/session_controller.ex
@@ -53,6 +53,9 @@ defmodule DbserviceWeb.SessionController do
         case String.to_existing_atom(key) do
           :offset -> acc
           :limit -> acc
+          :session_id_is_null when value == "true" ->
+            # filter for session_id being null
+            from u in acc, where: is_nil(u.session_id)
           atom -> from u in acc, where: field(u, ^atom) == ^value
         end
       end)

--- a/lib/dbservice_web/controllers/session_controller.ex
+++ b/lib/dbservice_web/controllers/session_controller.ex
@@ -66,7 +66,7 @@ defmodule DbserviceWeb.SessionController do
             apply_session_id_null_filter(value, acc)
 
           _ ->
-            from u in acc, where: fragment("? = ?", field(u, ^key), ^value)
+            from u in acc, where: field(u, ^key) == ^value
         end
       end)
 


### PR DESCRIPTION
This PR updates session controller GET request to enable the following:
- Get a list of sessions with `id` in descending order (using offset and limit)
- Get sessions with `session_id_is_null=true` 

So, a command like : `curl -X GET "http://localhost:4000/api/session?session_id_is_null=true&offset=0&limit=10" -H  "accept: application/json"` gives the latest ten sessions with id as null. 

This will be used by `quiz-creator` frontend to display sessions whose ID has not yet been generated. 

Additionally, this PR also updates local installation instructions for this repo.
