### PR TITLE
Fix: Rename batch to batch_id

### DIFF
--- a/lib/dbservice_web/controllers/user_controller.ex
+++ b/lib/dbservice_web/controllers/user_controller.ex
@@ -221,8 +221,8 @@ defmodule DbserviceWeb.UserController do
         false
 
       session ->
-        if quiz_flag && session.meta_data["batch"] != "" do
-          session.meta_data["batch"] == class_batch_id and session.platform == "quiz"
+        if quiz_flag && session.meta_data["batch_id"] != "" do
+          session.meta_data["batch_id"] == class_batch_id and session.platform == "quiz"
         else
           true
         end


### PR DESCRIPTION
### Description
- Renamed `batch` to `batch_id`