### PR TITLE
used join instead of nested loop

### DIFF
--- a/lib/dbservice/users.ex
+++ b/lib/dbservice/users.ex
@@ -463,4 +463,23 @@ defmodule Dbservice.Users do
     |> where(^Util.build_conditions(params))
     |> Repo.all()
   end
+
+  @doc """
+  Gets a list of students along with their associated users based on the given parameters.
+  Returns an empty list if no matching students or users are found.
+  """
+  def get_students_with_users(grade_id, category, date_of_birth, gender, first_name) do
+    from(s in Student,
+      join: u in User,
+      on: u.id == s.user_id,
+      where:
+        s.grade_id == ^grade_id and
+          s.category == ^category and
+          u.date_of_birth == ^date_of_birth and
+          u.gender == ^gender and
+          u.first_name == ^first_name,
+      select: {s, u}
+    )
+    |> Repo.all()
+  end
 end


### PR DESCRIPTION
### Problem Statement
In the PR: [added create_student_id endpoint with its helper functions in student… #187](https://github.com/avantifellows/db-service/pull/187)
We were using nested loops:
-> First we get existing students with `grade` and `category` from parameters.
-> Then we run a loop for each existing student to get existing user with `date_of_birth`, `gender`, `first_name` from parameters.
-> Then we loop to find enrollment record for each user if they are enrolled in the school specified in parameters.
### Result
This resulted in high response time(more than 30 seconds) of generating a student id or fetching an existing student id.

### Solution
We have now used a join between `student` table and `user` table to reduce the high response time.

