### PR TITLE
Bugfix: Fix user-session timestamp validation for IST

### DIFF
--- a/lib/dbservice/utils/util.ex
+++ b/lib/dbservice/utils/util.ex
@@ -6,10 +6,20 @@ defmodule Dbservice.Utils.Util do
   import Ecto.Query
 
   def invalidate_future_date(changeset, date_field_atom) do
-    today = Date.utc_today()
+    utc_now = DateTime.utc_now()
+
+    ist_now = DateTime.add(utc_now, 5 * 60 * 60 + 30 * 60, :second)
+
     date_to_validate = get_field(changeset, date_field_atom)
 
-    if Date.compare(date_to_validate, today) == :gt do
+    date_to_validate =
+      case date_to_validate do
+        %DateTime{} -> date_to_validate
+        %NaiveDateTime{} -> DateTime.from_naive!(date_to_validate, "Etc/UTC")
+        _ -> raise "Unsupported date format"
+      end
+
+    if DateTime.compare(date_to_validate, ist_now) == :gt do
       add_error(changeset, date_field_atom, "cannot be later than today")
     else
       changeset

--- a/lib/dbservice/utils/util.ex
+++ b/lib/dbservice/utils/util.ex
@@ -12,13 +12,6 @@ defmodule Dbservice.Utils.Util do
 
     date_to_validate = get_field(changeset, date_field_atom)
 
-    date_to_validate =
-      case date_to_validate do
-        %DateTime{} -> date_to_validate
-        %NaiveDateTime{} -> DateTime.from_naive!(date_to_validate, "Etc/UTC")
-        _ -> raise "Unsupported date format"
-      end
-
     if DateTime.compare(date_to_validate, ist_now) == :gt do
       add_error(changeset, date_field_atom, "cannot be later than today")
     else


### PR DESCRIPTION
### Description
- Updated `invalidate_future_date` function in Utils module to use DateTime for IST conversions and comparisons.

### Checklist
- [x] Local testing
