### PR TITLE
Get auth group from session id

### DIFF
--- a/lib/dbservice/group_sessions.ex
+++ b/lib/dbservice/group_sessions.ex
@@ -51,6 +51,22 @@ defmodule Dbservice.GroupSessions do
   end
 
   @doc """
+    Gets all group-sessions by session ID.
+    Returns an empty list if no GroupSessions exist for the given session ID.
+    ## Examples
+        iex> get_all_group_sessions_by_session_id(1234)
+        [%GroupSession{}, ...]
+
+        iex> get_all_group_sessions_by_session_id(9999)
+        []
+  """
+
+  def get_all_group_sessions_by_session_id(session_id) do
+    from(gs in GroupSession, where: gs.session_id == ^session_id)
+    |> Repo.all()
+  end
+
+  @doc """
   Gets a group-session by group ID.
   Raises `Ecto.NoResultsError` if the GroupSession does not exist.
   ## Examples

--- a/lib/dbservice_web/controllers/group_session_controller.ex
+++ b/lib/dbservice_web/controllers/group_session_controller.ex
@@ -184,12 +184,13 @@ defmodule DbserviceWeb.GroupSessionController do
   end
 
   defp get_group(group_sessions) do
-    batch_group = Enum.find_value(group_sessions, fn group_session ->
-      case Groups.get_group!(group_session.group_id) do
-        %{type: "batch"} = group -> group
-        _ -> nil
-      end
-    end)
+    batch_group =
+      Enum.find_value(group_sessions, fn group_session ->
+        case Groups.get_group!(group_session.group_id) do
+          %{type: "batch"} = group -> group
+          _ -> nil
+        end
+      end)
 
     case batch_group do
       nil -> {:error, :not_found, "Batch group not found"}

--- a/lib/dbservice_web/controllers/student_controller.ex
+++ b/lib/dbservice_web/controllers/student_controller.ex
@@ -457,16 +457,21 @@ defmodule DbserviceWeb.StudentController do
   end
 
   defp check_enrollment_and_get_id(user, student_id, params) do
-    case Schools.get_school_by_code(params["school_code"]) do
-      nil ->
-        {:error, "No school found with the given school code"}
+    region = if params["region"] == "", do: nil, else: params["region"]
 
-      school ->
+    case Schools.get_school_by_params(%{name: params["school_name"], region: region}) do
+      [] ->
+        {:error, "No school found with the given name and region"}
+
+      [school] ->
         if check_existing_enrollment(user.id, school.id) do
           {:ok, student_id}
         else
           {:ok, nil}
         end
+
+      _ ->
+        {:error, "multiple school found with the given name and region"}
     end
   end
 
@@ -483,26 +488,31 @@ defmodule DbserviceWeb.StudentController do
 
   defp generate_new_student_id(params) do
     counter = 1000
-    try_generate_id(counter, params)
+    case get_school_code(params) do
+      {:ok, school_code} ->
+        try_generate_id(counter, params, school_code)
+
+      {:error, message} ->
+        {:error, message}
+    end
   end
 
-  defp try_generate_id(0, _params) do
+  defp try_generate_id(0, _params, _school_code) do
     {:error, "Student ID could not be generated. Max attempts hit!"}
   end
 
-  defp try_generate_id(attempts_left, params) do
-    id = generate_new_id(params)
+  defp try_generate_id(attempts_left, params, school_code) do
+    id = generate_new_id(params, school_code)
 
     if check_if_generated_id_already_exists(id) do
-      try_generate_id(attempts_left - 1, params)
+      try_generate_id(attempts_left - 1, params, school_code)
     else
       {:ok, id}
     end
   end
 
-  defp generate_new_id(params) do
+  defp generate_new_id(params, school_code) do
     class_code = get_class_code(params["grade"])
-    school_code = params["school_code"]
     three_digit_code = generate_three_digit_code()
 
     class_code <> school_code <> three_digit_code
@@ -519,6 +529,21 @@ defmodule DbserviceWeb.StudentController do
     graduating_year
     |> Integer.to_string()
     |> String.slice(-2..-1)
+  end
+
+  defp get_school_code(params) do
+    region = if params["region"] == "", do: nil, else: params["region"]
+
+    case Schools.get_school_by_params(%{region: region, name: params["school_name"]}) do
+      [] ->
+        {:error, "No school found with the given name and region"}
+
+      [school] ->
+        {:ok, school.code}
+
+      _ ->
+        {:error, "multiple school found with the given name and region"}
+    end
   end
 
   defp generate_three_digit_code do

--- a/lib/dbservice_web/controllers/student_controller.ex
+++ b/lib/dbservice_web/controllers/student_controller.ex
@@ -488,6 +488,7 @@ defmodule DbserviceWeb.StudentController do
 
   defp generate_new_student_id(params) do
     counter = 1000
+
     case get_school_code(params) do
       {:ok, school_code} ->
         try_generate_id(counter, params, school_code)

--- a/lib/dbservice_web/router.ex
+++ b/lib/dbservice_web/router.ex
@@ -29,6 +29,7 @@ defmodule DbserviceWeb.Router do
     post("/session/:id/update-groups", SessionController, :update_groups)
     resources("/session-occurrence", SessionOccurenceController, except: [:new, :edit])
     resources("/user-session", UserSessionController, except: [:new, :edit])
+    get("/group-session/session-auth-group", GroupSessionController, :get_auth_group_from_session)
     resources("/group-session", GroupSessionController, except: [:new, :edit])
     resources("/product", ProductController)
     resources("/program", ProgramController, except: [:new, :edit])


### PR DESCRIPTION
### Summary

- This PR moves the logic for retrieving auth group data from the portal-backend to the db-service. This change aims to optimize our API structure by reducing multiple API calls to a single call.

### Changes

- Implemented new endpoint in db-service: `GET /api/group-session/session-auth-group`
- Added `get_auth_group_from_session` function in `GroupSessionController`
- Implemented logic to traverse from `session_id` to `auth_group` through related entities

### Technical Details

- The new endpoint accepts a `session_id `as a query parameter
- The function chain traverses from `GroupSession `-> `Group `-> `Batch `-> `AuthGroup`
- Error handling has been implemented for cases where any entity in the chain is not found