### PR TITLE
Added functionality to create user for existing school if user doesn't exist

### DIFF
--- a/lib/dbservice_web/controllers/school_controller.ex
+++ b/lib/dbservice_web/controllers/school_controller.ex
@@ -6,6 +6,7 @@ defmodule DbserviceWeb.SchoolController do
   alias Dbservice.Schools
   alias Dbservice.Schools.School
   alias Dbservice.Users
+  alias Dbservice.Users.User
 
   action_fallback DbserviceWeb.FallbackController
 
@@ -169,7 +170,15 @@ defmodule DbserviceWeb.SchoolController do
   end
 
   defp update_existing_school_with_user(conn, existing_school, params) do
-    user = Users.get_user!(existing_school.user_id)
+    user =
+      case existing_school.user_id do
+        nil ->
+          {:ok, %User{} = user} = Users.create_user(params)
+          user
+
+        user_id ->
+          Users.get_user!(user_id)
+      end
 
     with {:ok, %School{} = school} <-
            Schools.update_school_with_user(existing_school, user, params) do


### PR DESCRIPTION
### Description
This PR introduces functionality to handle scenarios where an existing school does not have an associated user. If a school is found without a user, a new user will be created and associated with that school before updating the school details.

- Updated `update_existing_school_with_user` to check if `existing_school.user_id` is nil.
- If `user_id` is nil, a new user is created using `Users.create_user`
- The new user is then associated with the school, and the school details are updated.
- If `user_id` is not nil, the existing user is retrieved and the school details are updated accordingly.