### PR TITLE
Refactor `update_by_type` to support updation of the provided batch and fix group preloading

### DIFF
--- a/lib/dbservice/group_users.ex
+++ b/lib/dbservice/group_users.ex
@@ -66,7 +66,8 @@ defmodule Dbservice.GroupUsers do
       join: g in Group,
       on: gu.group_id == g.id,
       where: gu.user_id == ^user_id and g.type == ^type,
-      select: gu
+      select: gu,
+      preload: [:group]
     )
     |> Repo.all()
   end

--- a/lib/dbservice_web/controllers/group_user_controller.ex
+++ b/lib/dbservice_web/controllers/group_user_controller.ex
@@ -129,8 +129,8 @@ defmodule DbserviceWeb.GroupUserController do
     group_user_to_update =
       case type do
         "batch" ->
-          current_batch_id = params["current_batch_pk"]
-          Enum.find(group_users, fn gu -> gu.group.child_id == current_batch_id end)
+          current_batch_pk = params["current_batch_pk"]
+          Enum.find(group_users, fn gu -> gu.group.child_id == current_batch_pk end)
 
         _ ->
           # For non-batch types, just take the first (and likely only) GroupUser
@@ -141,13 +141,13 @@ defmodule DbserviceWeb.GroupUserController do
     enrollment_record =
       case type do
         "batch" ->
-          current_batch_id = params["current_batch_pk"]
+          current_batch_pk = params["current_batch_pk"]
 
           from(er in EnrollmentRecord,
             where:
               er.user_id == ^user_id and
                 er.group_type == ^type and
-                er.group_id == ^current_batch_id
+                er.group_id == ^current_batch_pk
           )
           |> Repo.one()
 

--- a/lib/dbservice_web/controllers/group_user_controller.ex
+++ b/lib/dbservice_web/controllers/group_user_controller.ex
@@ -119,20 +119,48 @@ defmodule DbserviceWeb.GroupUserController do
   def update_by_type(conn, params) do
     user_id = params["user_id"]
     type = params["type"]
-    group = Groups.get_group_by_group_id_and_type(params["group_id"], type)
-    new_group_id = group.child_id
+    new_group = Groups.get_group_by_group_id_and_type(params["group_id"], type)
+    new_group_id = new_group.child_id
 
-    # Fetch the GroupUser with the specified user_id and where the group type is the provided type
-    group_user =
-      GroupUsers.get_group_user_by_user_id_and_type(user_id, type)
-      |> List.first()
+    # Fetch all GroupUsers for the specified user_id and type
+    group_users = GroupUsers.get_group_user_by_user_id_and_type(user_id, type)
 
-    # Fetch the EnrollmentRecord with the specified user_id and where the group_type matches the provided type
+    # Determine which GroupUser to update based on the type and provided params
+    group_user_to_update =
+      case type do
+        "batch" ->
+          current_batch_id = params["current_batch_pk"]
+          Enum.find(group_users, fn gu -> gu.group.child_id == current_batch_id end)
+
+        _ ->
+          # For non-batch types, just take the first (and likely only) GroupUser
+          List.first(group_users)
+      end
+
+    # Fetch the corresponding EnrollmentRecord
     enrollment_record =
-      from(er in EnrollmentRecord, where: er.user_id == ^user_id and er.group_type == ^type)
-      |> Repo.one()
+      case type do
+        "batch" ->
+          current_batch_id = params["current_batch_pk"]
 
-    case {group_user, enrollment_record} do
+          from(er in EnrollmentRecord,
+            where:
+              er.user_id == ^user_id and
+                er.group_type == ^type and
+                er.group_id == ^current_batch_id
+          )
+          |> Repo.one()
+
+        _ ->
+          from(er in EnrollmentRecord,
+            where:
+              er.user_id == ^user_id and
+                er.group_type == ^type
+          )
+          |> Repo.one()
+      end
+
+    case {group_user_to_update, enrollment_record} do
       {nil, _} ->
         # GroupUser not found
         {:error, :not_found}
@@ -143,14 +171,36 @@ defmodule DbserviceWeb.GroupUserController do
 
       {group_user, enrollment_record} ->
         # Update both the GroupUser and the EnrollmentRecord
-        with {:ok, %GroupUser{} = updated_group_user} <-
-               GroupUsers.update_group_user(group_user, params),
-             {:ok, %EnrollmentRecord{} = _updated_enrollment_record} <-
-               EnrollmentRecords.update_enrollment_record(enrollment_record, %{
-                 "group_id" => new_group_id
-               }) do
-          render(conn, "show.json", group_user: updated_group_user)
-        end
+        update_group_user_and_enrollment(
+          conn,
+          group_user,
+          enrollment_record,
+          params,
+          new_group_id
+        )
+    end
+  end
+
+  defp update_group_user_and_enrollment(conn, group_user, enrollment_record, params, new_group_id) do
+    Repo.transaction(fn ->
+      with {:ok, %GroupUser{} = updated_group_user} <-
+             GroupUsers.update_group_user(group_user, %{group_id: params["group_id"]}),
+           {:ok, %EnrollmentRecord{} = updated_enrollment_record} <-
+             EnrollmentRecords.update_enrollment_record(enrollment_record, %{
+               "group_id" => new_group_id
+             }) do
+        {updated_group_user, updated_enrollment_record}
+      else
+        {:error, failed_operation} ->
+          Repo.rollback(failed_operation)
+      end
+    end)
+    |> case do
+      {:ok, {updated_group_user, _updated_enrollment_record}} ->
+        render(conn, "show.json", group_user: updated_group_user)
+
+      {:error, reason} ->
+        {:error, reason}
     end
   end
 


### PR DESCRIPTION
### Description

This commit enhances the `update_by_type` functionality in the GroupUserController and addresses related issues:

1. Adds support for updating multiple batches per user while maintaining compatibility with single-association group types (like school or auth_group).

2. Fixes the KeyError caused by the :group association not being preloaded in the GroupUsers query.

3. Improves error handling and response formatting in the controller.

### Key changes:

- Modified `get_group_users_by_user_id_and_type/2` in GroupUsers module to preload the :group association.
- Updated `update_by_type/2` in GroupUserController to handle both batch and non-batch group types differently.
- Implemented case-specific logic for selecting the correct GroupUser and EnrollmentRecord to update.
- Enhanced error handling to return appropriate JSON responses with status codes.
- Adjusted `update_group_user_and_enrollment/5` to return JSON responses for both successful and error cases.


### Checklist
- [x] Local testing
