### PR TITLE
Feat: API to delete student from db

### DIFF
--- a/lib/dbservice_web/controllers/user_session_controller.ex
+++ b/lib/dbservice_web/controllers/user_session_controller.ex
@@ -5,6 +5,10 @@ defmodule DbserviceWeb.UserSessionController do
   alias Dbservice.Repo
   alias Dbservice.Sessions
   alias Dbservice.Sessions.UserSession
+  alias Dbservice.Users.User
+  alias Dbservice.Users.Student
+  alias Dbservice.Groups.GroupUser
+  alias Dbservice.EnrollmentRecords.EnrollmentRecord
 
   action_fallback DbserviceWeb.FallbackController
 
@@ -126,5 +130,81 @@ defmodule DbserviceWeb.UserSessionController do
     with {:ok, %UserSession{}} <- Sessions.delete_user_session(user_session) do
       send_resp(conn, :no_content, "")
     end
+  end
+
+  def cleanup_student(conn, %{"student_id" => student_id}) do
+    with {:ok, student} <- get_student(student_id),
+         {:ok, user_id} <- extract_user_id(student),
+         :ok <- check_no_active_session(user_id),
+         {:ok, _} <- delete_student_and_related_data(student) do
+      send_resp(conn, 200, "Student deleted successfully!")
+    else
+      {:error, :not_found} ->
+        conn
+        |> put_status(:not_found)
+        |> json(%{error: "Student not found"})
+
+      {:error, :active_session_exists} ->
+        conn
+        |> put_status(:bad_request)
+        |> json(%{error: "Active session exists for the user"})
+
+      {:error, reason} ->
+        conn
+        |> put_status(:bad_request)
+        |> json(%{error: "Error occurred: #{inspect(reason)}"})
+    end
+  end
+
+  defp get_student(student_id) do
+    case Repo.get_by(Student, student_id: student_id) do
+      nil -> {:error, :not_found}
+      student -> {:ok, student}
+    end
+  end
+
+  defp extract_user_id(student) do
+    case student.user_id do
+      nil -> {:error, :user_id_not_found}
+      user_id -> {:ok, user_id}
+    end
+  end
+
+  defp check_no_active_session(user_id) do
+    if Repo.exists?(from u in UserSession, where: u.user_id == ^user_id) do
+      {:error, :active_session_exists}
+    else
+      :ok
+    end
+  end
+
+  defp delete_student_and_related_data(student) do
+    Repo.transaction(fn ->
+      with {:ok, _} <- Repo.delete(student),
+           {:ok, _} <- delete_enrollment_record(student.user_id),
+           {:ok, _} <- delete_group_user(student.user_id),
+           {:ok, _} <- delete_user(student.user_id) do
+        {:ok, :deleted}
+      else
+        error -> Repo.rollback(error)
+      end
+    end)
+  end
+
+  defp delete_user(user_id) do
+    case Repo.get(User, user_id) do
+      nil -> {:ok, :not_found}
+      user -> Repo.delete(user)
+    end
+  end
+
+  defp delete_group_user(user_id) do
+    {count, _} = from(gu in GroupUser, where: gu.user_id == ^user_id) |> Repo.delete_all()
+    {:ok, count}
+  end
+
+  defp delete_enrollment_record(user_id) do
+    {count, _} = from(er in EnrollmentRecord, where: er.user_id == ^user_id) |> Repo.delete_all()
+    {:ok, count}
   end
 end

--- a/lib/dbservice_web/router.ex
+++ b/lib/dbservice_web/router.ex
@@ -61,6 +61,7 @@ defmodule DbserviceWeb.Router do
     patch("/update-group-user-by-type", GroupUserController, :update_by_type)
     patch("/update-user-enrollment-records", StudentController, :update_user_enrollment_records)
     patch("/student/update-status/:student_id", StudentController, :update_student_status)
+    delete("/cleanup-student/:student_id", UserSessionController, :cleanup_student)
 
     def swagger_info do
       source(["config/.env", "config/.env"])


### PR DESCRIPTION
### Description
- This PR introduces functionality to clean up duplicate student records from the database by checking their session attendance before deletion. We verify if a student has attended at least one session before deciding to delete or retain their record. 

### Checklist
- [x] Local testing