### PR TITLE
Fix: Enhance Dropout Enrollment with Custom Start Date

### DIFF
--- a/lib/dbservice_web/controllers/student_controller.ex
+++ b/lib/dbservice_web/controllers/student_controller.ex
@@ -188,7 +188,7 @@ defmodule DbserviceWeb.StudentController do
     end
   end
 
-  def dropout(conn, %{"student_id" => student_id}) do
+  def dropout(conn, %{"student_id" => student_id, "start_date" => dropout_start_date}) do
     student = Users.get_student_by_student_id(student_id)
 
     # Check if the student's status is already 'dropout'
@@ -198,7 +198,6 @@ defmodule DbserviceWeb.StudentController do
       |> json(%{errors: "Student is already marked as dropout"})
     else
       user_id = student.user_id
-      current_time = DateTime.utc_now()
 
       # Fetch status and group details in a single query
       {status_id, group_type} =
@@ -224,7 +223,7 @@ defmodule DbserviceWeb.StudentController do
       Enum.each(current_enrollments, fn enrollment ->
         EnrollmentRecords.update_enrollment_record(enrollment, %{
           is_current: false,
-          end_date: current_time
+          end_date: dropout_start_date
         })
       end)
 
@@ -232,7 +231,7 @@ defmodule DbserviceWeb.StudentController do
       new_enrollment_attrs = %{
         user_id: user_id,
         is_current: true,
-        start_date: current_time,
+        start_date: dropout_start_date,
         group_id: status_id,
         group_type: group_type,
         academic_year: academic_year,


### PR DESCRIPTION
### Description
- This update modifies the dropout functionality to allow a custom start date for the dropout enrollment record. The provided start date will also be used as the end date for all current student enrollment records.

### Checklist
- [x] Local testing