### PR TITLE
Feat: Remove academic_year for auth_group enrollment records

### DIFF
--- a/lib/dbservice/enrollment_record/enrollment_record.ex
+++ b/lib/dbservice/enrollment_record/enrollment_record.ex
@@ -27,6 +27,10 @@ defmodule Dbservice.EnrollmentRecords.EnrollmentRecord do
 
   @doc false
   def changeset(enrollment_record, attrs) do
+    required_fields = [:user_id, :group_id, :group_type, :start_date, :grade_id]
+    required_fields =
+      if Map.get(attrs, "group_type") == "auth_group", do: required_fields, else: [:academic_year | required_fields]
+
     enrollment_record
     |> cast(attrs, [
       :user_id,
@@ -39,13 +43,7 @@ defmodule Dbservice.EnrollmentRecords.EnrollmentRecord do
       :grade_id,
       :subject_id
     ])
-    |> validate_required([
-      :user_id,
-      :group_id,
-      :group_type,
-      :start_date,
-      :grade_id
-    ])
+    |> validate_required(required_fields)
     |> validate_dates_of_enrollment
   end
 

--- a/lib/dbservice/enrollment_record/enrollment_record.ex
+++ b/lib/dbservice/enrollment_record/enrollment_record.ex
@@ -44,7 +44,6 @@ defmodule Dbservice.EnrollmentRecords.EnrollmentRecord do
       :group_id,
       :group_type,
       :start_date,
-      :academic_year,
       :grade_id
     ])
     |> validate_dates_of_enrollment

--- a/lib/dbservice/enrollment_record/enrollment_record.ex
+++ b/lib/dbservice/enrollment_record/enrollment_record.ex
@@ -28,8 +28,11 @@ defmodule Dbservice.EnrollmentRecords.EnrollmentRecord do
   @doc false
   def changeset(enrollment_record, attrs) do
     required_fields = [:user_id, :group_id, :group_type, :start_date, :grade_id]
+
     required_fields =
-      if Map.get(attrs, "group_type") == "auth_group", do: required_fields, else: [:academic_year | required_fields]
+      if Map.get(attrs, "group_type") == "auth_group",
+        do: required_fields,
+        else: [:academic_year | required_fields]
 
     enrollment_record
     |> cast(attrs, [

--- a/lib/dbservice_web/controllers/group_user_controller.ex
+++ b/lib/dbservice_web/controllers/group_user_controller.ex
@@ -231,12 +231,7 @@ defmodule DbserviceWeb.GroupUserController do
   defp create_new_group_user(conn, params) do
     group = Groups.get_group!(params["group_id"])
 
-    academic_year =
-      if group.type == "auth_group" do
-        nil
-      else
-        params["academic_year"]
-      end
+    academic_year = resolve_academic_year(group.type, params)
 
     enrollment_record = %{
       "group_id" => group.child_id,
@@ -370,12 +365,7 @@ defmodule DbserviceWeb.GroupUserController do
   defp create_new_group_user_from_batch(params) do
     group = Groups.get_group!(params["group_id"])
 
-    academic_year =
-      if group.type == "auth_group" do
-        nil
-      else
-        params["academic_year"]
-      end
+    academic_year = resolve_academic_year(group.type, params)
 
     enrollment_record = %{
       "group_id" => group.child_id,
@@ -399,6 +389,14 @@ defmodule DbserviceWeb.GroupUserController do
     case GroupUsers.update_group_user(existing_group_user, params) do
       {:ok, group_user} -> {:ok, group_user}
       {:error, _changeset} -> {:error, "Failed to update group user. Some problem with changeset"}
+    end
+  end
+
+  defp resolve_academic_year(group_type, params) do
+    if group_type == "auth_group" do
+      nil
+    else
+      params["academic_year"]
     end
   end
 end

--- a/lib/dbservice_web/controllers/group_user_controller.ex
+++ b/lib/dbservice_web/controllers/group_user_controller.ex
@@ -370,12 +370,19 @@ defmodule DbserviceWeb.GroupUserController do
   defp create_new_group_user_from_batch(params) do
     group = Groups.get_group!(params["group_id"])
 
+    academic_year =
+      if group.type == "auth_group" do
+        nil
+      else
+        params["academic_year"]
+      end
+
     enrollment_record = %{
       "group_id" => group.child_id,
       "group_type" => group.type,
       "user_id" => params["user_id"],
       "grade_id" => params["grade_id"],
-      "academic_year" => params["academic_year"],
+      "academic_year" => academic_year,
       "start_date" => params["start_date"]
     }
 

--- a/lib/dbservice_web/controllers/group_user_controller.ex
+++ b/lib/dbservice_web/controllers/group_user_controller.ex
@@ -231,12 +231,19 @@ defmodule DbserviceWeb.GroupUserController do
   defp create_new_group_user(conn, params) do
     group = Groups.get_group!(params["group_id"])
 
+    academic_year =
+      if group.type == "auth_group" do
+        nil
+      else
+        params["academic_year"]
+      end
+
     enrollment_record = %{
       "group_id" => group.child_id,
       "group_type" => group.type,
       "user_id" => params["user_id"],
       "grade_id" => params["grade_id"],
-      "academic_year" => params["academic_year"],
+      "academic_year" => academic_year,
       "start_date" => params["start_date"]
     }
 

--- a/priv/repo/migrations/20241206075101_remove_academic_year_from_auth_group_er.exs
+++ b/priv/repo/migrations/20241206075101_remove_academic_year_from_auth_group_er.exs
@@ -1,0 +1,15 @@
+defmodule Dbservice.Repo.Migrations.RemoveAcademicYearFromAuthGroupEr do
+  use Ecto.Migration
+
+  def up do
+    execute """
+    UPDATE enrollment_record
+    SET academic_year = NULL
+    WHERE group_type = 'auth_group'
+    """
+  end
+
+  def down do
+    execute "-- No reliable way to restore previous academic_year values"
+  end
+end


### PR DESCRIPTION
### Description

This PR addresses an issue with academic year handling for auth group enrollment records by:

- Removing academic_year for auth group during batch processing
- Updating the database to clear existing academic year values for auth groups
- Adding logic to prevent setting academic year for auth group enrollments

### Checklist
- [x] Local testing