### PR TITLE
Feat: API endpoint to remove specific batch mapping for a student

### DIFF
--- a/lib/dbservice_web/router.ex
+++ b/lib/dbservice_web/router.ex
@@ -65,6 +65,7 @@ defmodule DbserviceWeb.Router do
     post("/group-user/batch-process", GroupUserController, :batch_process)
     patch("/student/update-status/:student_id", StudentController, :update_student_status)
     delete("/cleanup-student/:student_id", UserSessionController, :cleanup_student)
+    delete("/remove-batch/:student_id/:batch_id", UserSessionController, :remove_batch_mapping)
 
     def swagger_info do
       source(["config/.env", "config/.env"])


### PR DESCRIPTION
### Description
- This PR adds functionality to remove a specific batch mapping for a student. This is needed when a student is mapped to incorrect batches and we want to remove one of those mappings.

### Changes:
- Added new DELETE endpoint `/remove-batch/:student_id/:batch_id`
- Added batch lookup using batch_id (string)
- Implemented deletion of corresponding records from:
  - group_user table (using group mapping)
  - enrollment_record table
- Added transaction support to ensure data consistency
- Added proper error handling for various failure cases

The endpoint requires:
- student_id: Student's unique identifier
- batch_id: Batch's string identifier

Error handling covers:
- Student not found
- Batch not found 
- Missing user mapping
- Group mapping not found

Testing:
- [x] Local testing