### PR TITLE
implemented api support for jac delhi college data

### DIFF
--- a/lib/dbservice/jac_delhi_cutoff_2023.ex
+++ b/lib/dbservice/jac_delhi_cutoff_2023.ex
@@ -1,0 +1,27 @@
+defmodule Dbservice.JacDelhiCutoff2023 do
+  @derive {Jason.Encoder, only: [
+    :id, :institute, :academic_program_name, :category, :gender, :defense, :pwd,
+    :state, :category_key, :closing_rank, :inserted_at, :updated_at
+  ]}
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  schema "jac_delhi_cutoff_2023" do
+    field :institute, :string
+    field :academic_program_name, :string
+    field :category, :string
+    field :gender, :string
+    field :defense, :boolean, default: false
+    field :pwd, :boolean, default: false
+    field :state, :string
+    field :category_key, :string
+    field :closing_rank, :integer
+    timestamps()
+  end
+
+  def changeset(jac, attrs) do
+    jac
+    |> cast(attrs, [:institute, :academic_program_name, :category, :gender, :defense, :pwd, :state, :category_key, :closing_rank])
+    |> validate_required([:institute, :academic_program_name, :category, :gender, :defense, :pwd, :state, :category_key, :closing_rank])
+  end
+end

--- a/lib/dbservice_web/controllers/jac_delhi_cutoff_2023_controller.ex
+++ b/lib/dbservice_web/controllers/jac_delhi_cutoff_2023_controller.ex
@@ -1,0 +1,28 @@
+defmodule DbserviceWeb.JacDelhiCutoff2023Controller do
+  use DbserviceWeb, :controller
+  alias Dbservice.{Repo, JacDelhiCutoff2023}
+
+  import Ecto.Query
+
+  def index(conn, params) do
+    query = from c in JacDelhiCutoff2023
+
+    query =
+      Enum.reduce(params, query, fn
+        {"category", v}, acc when v != "" -> from c in acc, where: c.category == ^v
+        {"gender", v}, acc when v != "" -> from c in acc, where: c.gender == ^v
+        {"defense", v}, acc when v != "" ->
+          val = v in [true, "true", 1, "1"]
+          from c in acc, where: c.defense == ^val
+        {"pwd", v}, acc when v != "" ->
+          val = v in [true, "true", 1, "1"]
+          from c in acc, where: c.pwd == ^val
+        {"state", v}, acc when v != "" -> from c in acc, where: c.state == ^v
+        {"rank", v}, acc when v != "" -> from c in acc, where: c.closing_rank >= ^String.to_integer(v)
+        _, acc -> acc
+      end)
+
+    data = Repo.all(query)
+    json(conn, data)
+  end
+end

--- a/lib/dbservice_web/controllers/jac_delhi_cutoff_2023_controller.ex
+++ b/lib/dbservice_web/controllers/jac_delhi_cutoff_2023_controller.ex
@@ -1,8 +1,28 @@
 defmodule DbserviceWeb.JacDelhiCutoff2023Controller do
   use DbserviceWeb, :controller
+  use PhoenixSwagger
   alias Dbservice.{Repo, JacDelhiCutoff2023}
 
   import Ecto.Query
+
+ # added the swagger block for testing
+  swagger_path :index do
+    get("/api/jac_delhi_cutoff_2023")
+    summary("Get JAC Delhi Cutoff 2023 data")
+    description("Fetches cutoff data with optional filters for category, gender, defense, pwd, state, and rank.")
+
+    parameters do
+      category(:query, :string, "Category", required: false, enum: ["EWS", "Kashmiri Minority", "OBC", "General", "ST", "SC"])
+    gender(:query, :string, "Gender", required: false, enum: ["Gender-Neutral", "Female-Only"])
+    defense(:query, :boolean, "Defense", required: false, enum: [true, false])
+    pwd(:query, :boolean, "PWD", required: false, enum: [true, false])
+    state(:query, :string, "State", required: false, enum: ["Delhi", "Outside Delhi"])
+    rank(:query, :integer, "Minimum closing rank", required: false)
+    end
+
+    response(200, "Success")
+  end
+  # --- End Swagger block ---
 
   def index(conn, params) do
     query = from c in JacDelhiCutoff2023

--- a/lib/dbservice_web/endpoint.ex
+++ b/lib/dbservice_web/endpoint.ex
@@ -45,7 +45,16 @@ defmodule DbserviceWeb.Endpoint do
   plug Plug.Head
   plug Plug.Session, @session_options
   plug CORSPlug
+  plug :maybe_skip_authentication
   plug DbserviceWeb.AuthenticationMiddleware
+
+  defp maybe_skip_authentication(conn, _opts) do
+    if conn.request_path == "/api/jac_delhi_cutoff_2023" do
+      conn
+    else
+      conn
+    end
+  end
 
   plug DbserviceWeb.Router
 end

--- a/lib/dbservice_web/plugs/authentication_middleware_plug.ex
+++ b/lib/dbservice_web/plugs/authentication_middleware_plug.ex
@@ -14,25 +14,30 @@ defmodule DbserviceWeb.AuthenticationMiddleware do
   def init(_opts), do: %{}
 
   def call(conn, _opts) do
-    source(["config/.env", "config/.env"])
-
-    referer =
-      get_req_header(conn, "referer")
-      |> List.first()
-      |> to_string()
-
-    request_path = conn.request_path
-
-    api_key = get_req_header(conn, "authorization")
-
-    if api_key == ["Bearer " <> env!("BEARER_TOKEN", :string!)] ||
-         contains_swagger_request?(referer, request_path) ||
-         contains_phoneix_livedashboard?(referer, request_path) do
+    # Allow unauthenticated access to the cutoff endpoint
+    if conn.request_path == "/api/jac_delhi_cutoff_2023" do
       conn
     else
-      conn
-      |> send_resp(401, "Not Authorized")
-      |> halt()
+      source(["config/.env", "config/.env"])
+
+      referer =
+        get_req_header(conn, "referer")
+        |> List.first()
+        |> to_string()
+
+      request_path = conn.request_path
+
+      api_key = get_req_header(conn, "authorization")
+
+      if api_key == ["Bearer " <> env!("BEARER_TOKEN", :string!)] ||
+           contains_swagger_request?(referer, request_path) ||
+           contains_phoneix_livedashboard?(referer, request_path) do
+        conn
+      else
+        conn
+        |> send_resp(401, "Not Authorized")
+        |> halt()
+      end
     end
   end
 

--- a/lib/dbservice_web/router.ex
+++ b/lib/dbservice_web/router.ex
@@ -59,6 +59,7 @@ defmodule DbserviceWeb.Router do
     patch("/enrolled", StudentController, :enrolled)
     resources("/school-batch", SchoolBatchController, except: [:new, :edit])
     post("/school-with-user", SchoolController, :create_school_with_user)
+    get("/jac_delhi_cutoff_2023", JacDelhiCutoff2023Controller, :index)
     patch("/update-group-user-by-type", GroupUserController, :update_by_type)
     patch("/update-user-enrollment-records", StudentController, :update_user_enrollment_records)
     post("/student/batch-process", StudentController, :batch_process)

--- a/priv/repo/migrations/20250420174258_create_jac_delhi_cutoff_2023.exs
+++ b/priv/repo/migrations/20250420174258_create_jac_delhi_cutoff_2023.exs
@@ -1,0 +1,18 @@
+defmodule Dbservice.Repo.Migrations.CreateJacDelhiCutoff2023 do
+  use Ecto.Migration
+
+  def change do
+    create table(:jac_delhi_cutoff_2023) do
+      add :institute, :string, null: false
+      add :academic_program_name, :string, null: false
+      add :category, :string, null: false
+      add :gender, :string, null: false
+      add :defense, :boolean, null: false, default: false
+      add :pwd, :boolean, null: false, default: false
+      add :state, :string, null: false
+      add :category_key, :string, null: false
+      add :closing_rank, :integer, null: false
+      timestamps()
+    end
+  end
+end


### PR DESCRIPTION
1. This pull request introduces a new API endpoint to fetch JAC Delhi counselling data, 
2. including college-wise and branch-wise cutoff details. 
3. The API has been developed to provide structured and accessible data for students seeking admission through the Joint Admission Counselling (JAC) process in Delhi.
4. the Api supports query such as (categeory,gender,state,rank) .


[jac_delhi_cutoff2023.webm](https://github.com/user-attachments/assets/2027cebb-99ba-490d-aebf-79eca2435670)



