### PR TITLE
Feat: Update Student Category for Physically Handicapped Students (PWD)

### DIFF
--- a/priv/repo/migrations/20250709065309_update_student_category.exs
+++ b/priv/repo/migrations/20250709065309_update_student_category.exs
@@ -1,0 +1,39 @@
+defmodule Dbservice.Repo.Migrations.UpdateStudentCategory do
+  use Ecto.Migration
+
+  def up do
+    # Special case: Gen-EWS should become PWD-EWS
+    execute("""
+      UPDATE student
+      SET category = 'PWD-EWS'
+      WHERE physically_handicapped = true AND category = 'Gen-EWS';
+    """)
+
+    # All other categories: prepend PWD- if not already PWD-
+    execute("""
+      UPDATE student
+      SET category = 'PWD-' || category
+      WHERE physically_handicapped = true
+        AND category IS NOT NULL
+        AND category != ''
+        AND category != 'Gen-EWS'
+        AND category NOT LIKE 'PWD-%';
+    """)
+  end
+
+  def down do
+    # Revert PWD-EWS back to Gen-EWS only for those who were updated
+    execute("""
+      UPDATE student
+      SET category = 'Gen-EWS'
+      WHERE physically_handicapped = true AND category = 'PWD-EWS';
+    """)
+
+    # Revert PWD-<category> back to <category> for those who were updated
+    execute("""
+      UPDATE student
+      SET category = SUBSTRING(category FROM 5)
+      WHERE physically_handicapped = true AND category LIKE 'PWD-%' AND category != 'PWD-EWS';
+    """)
+  end
+end


### PR DESCRIPTION
### Description
This migration updates the category field in the student table for existing records where `physically_handicapped` is `true`:
- If the current category is `Gen-EWS`, it is changed to `PWD-EWS` (not `PWD-Gen-EWS`).
- For all other categories (except those already starting with PWD-), the value is updated by prepending PWD- (e.g., `Gen` becomes `PWD-Gen`, `OBC` becomes `PWD-OBC`, etc.).
- The migration includes a reversible down function to restore the original categories for affected students.

### Checklist
- [x] Local testing