### PR TITLE
Feat: Optimize apply_time_filter/5 to handle continuous vs non-continuous sessions

### DIFF
--- a/lib/dbservice_web/controllers/session_occurence_controller.ex
+++ b/lib/dbservice_web/controllers/session_occurence_controller.ex
@@ -169,10 +169,17 @@ defmodule DbserviceWeb.SessionOccurrenceController do
   defp apply_time_filter(query, value, today_start, today_end, current_time) do
     case value do
       "today" ->
-        from(u in query, where: u.start_time >= ^today_start and u.start_time <= ^today_end)
+        from so in query,
+          join: s in assoc(so, :session),
+          where:
+            (fragment("?->>'type' = 'continuous'", s.repeat_schedule) and
+               so.start_time <= ^current_time and so.end_time >= ^current_time) or
+              (fragment("?->>'type' != 'continuous'", s.repeat_schedule) and
+                 so.start_time >= ^today_start and so.start_time <= ^today_end)
 
       "active" ->
-        from(u in query, where: u.start_time <= ^current_time and u.end_time >= ^current_time)
+        from so in query,
+          where: so.start_time <= ^current_time and so.end_time >= ^current_time
 
       _ ->
         query

--- a/lib/dbservice_web/controllers/session_occurence_controller.ex
+++ b/lib/dbservice_web/controllers/session_occurence_controller.ex
@@ -46,8 +46,6 @@ defmodule DbserviceWeb.SessionOccurrenceController do
     today = Date.utc_today()
 
     # Construct the beginning and end of today
-    today_start = NaiveDateTime.new!(today, ~T[00:00:00])
-    today_end = NaiveDateTime.new!(today, ~T[23:59:59])
 
     # Get current timestamp for active occurrence queries (when is_start_time="active")
     current_time = NaiveDateTime.utc_now() |> NaiveDateTime.add(5 * 3600 + 30 * 60, :second)
@@ -72,7 +70,7 @@ defmodule DbserviceWeb.SessionOccurrenceController do
             acc
 
           :is_start_time ->
-            apply_time_filter(acc, value, today_start, today_end, current_time)
+            apply_time_filter(acc, value, current_time)
 
           :session_ids ->
             from(u in acc, where: u.session_id in ^session_ids)
@@ -166,35 +164,17 @@ defmodule DbserviceWeb.SessionOccurrenceController do
     end
   end
 
-  defp apply_time_filter(query, value, today_start, today_end, current_time) do
+  defp apply_time_filter(query, value, current_time) do
     case value do
       "today" ->
-        from so in query,
-          join: s in assoc(so, :session),
-          where:
-            fragment(
-              """
-              CASE
-                WHEN (?->>'type') = 'continuous'
-                THEN (? <= ? AND ? >= ?)
-                ELSE (? >= ? AND ? <= ?)
-              END
-              """,
-              # from session table
-              s.repeat_schedule,
-              so.start_time,
-              ^current_time,
-              so.end_time,
-              ^current_time,
-              so.start_time,
-              ^today_start,
-              so.start_time,
-              ^today_end
-            )
+        from(so in query,
+          where: so.start_time <= ^current_time and so.end_time >= ^current_time
+        )
 
       "active" ->
-        from so in query,
+        from(so in query,
           where: so.start_time <= ^current_time and so.end_time >= ^current_time
+        )
 
       _ ->
         query


### PR DESCRIPTION
### Description
This PR refactors the apply_time_filter/5 function in SessionOccurrenceController to correctly filter sessions based on their repeat_schedule.type value.

### Changes Made
- Added a join with the sessions table to access repeat_schedule.
- Differentiated "today" filter logic:
   - Continuous sessions → considered active if current_time is between start_time and end_time.
   - Non-continuous sessions → considered active today if start_time falls within today’s date range.

### TODO
- [ ] Correct semantics in a separate PR

### Checklist
- [x] Local testing