### PR TITLE
Feat: Add indexes for foreign keys and frequently queried lookup fields

### DIFF
--- a/priv/repo/migrations/20250825075810_add_indexes_on_fk_and_lookup_fields.exs
+++ b/priv/repo/migrations/20250825075810_add_indexes_on_fk_and_lookup_fields.exs
@@ -14,12 +14,16 @@ defmodule Dbservice.Repo.Migrations.AddIndexesOnFkAndLookupFields do
 
     create index(:user_session, [:user_id])
     create index(:user_session, [:session_id])
+    create index(:user_session, [:session_occurrence_id])
 
     create index(:session_occurrence, [:session_fk])
+    create index(:session_occurrence, [:session_id])
 
     # Lookup / filter field indexes
+    create index(:user, [:email])
     create index(:user, [:phone])
     create index(:user, [:date_of_birth])
+    create index(:user, [:email, :phone])
 
     create index(:student, [:student_id])
     create index(:student, [:apaar_id])
@@ -41,8 +45,7 @@ defmodule Dbservice.Repo.Migrations.AddIndexesOnFkAndLookupFields do
     create index(:resource, [:type])
     create index(:resource, [:subtype])
 
-    create index(:group, [:type])
-    create index(:group, [:child_id])
+    create(index(:group, [:child_id, :type]))
 
     create index(:enrollment_record, [:group_type])
     create index(:enrollment_record, [:is_current])
@@ -51,7 +54,12 @@ defmodule Dbservice.Repo.Migrations.AddIndexesOnFkAndLookupFields do
     create index(:school, [:code])
     create index(:school, [:udise_code])
     create index(:school, [:state])
+    create index(:school, [:district])
 
     create index(:batch, [:batch_id])
+    create index(:batch, [:auth_group_id])
+
+    create index(:teacher, [:teacher_id])
+    create index(:auth_group, [:name])
   end
 end

--- a/priv/repo/migrations/20250825075810_add_indexes_on_fk_and_lookup_fields.exs
+++ b/priv/repo/migrations/20250825075810_add_indexes_on_fk_and_lookup_fields.exs
@@ -12,10 +12,6 @@ defmodule Dbservice.Repo.Migrations.AddIndexesOnFkAndLookupFields do
     create index(:group_session, [:group_id])
     create index(:group_session, [:session_id])
 
-    create index(:user_session, [:user_id])
-    create index(:user_session, [:session_id])
-    create index(:user_session, [:session_occurrence_id])
-
     create index(:session_occurrence, [:session_fk])
     create index(:session_occurrence, [:session_id])
 

--- a/priv/repo/migrations/20250825075810_add_indexes_on_fk_and_lookup_fields.exs
+++ b/priv/repo/migrations/20250825075810_add_indexes_on_fk_and_lookup_fields.exs
@@ -1,0 +1,57 @@
+defmodule Dbservice.Repo.Migrations.AddIndexesOnFkAndLookupFields do
+  use Ecto.Migration
+
+  def change do
+    # Foreign key indexes
+    create index(:group_user, [:user_id])
+    create index(:group_user, [:group_id])
+
+    create index(:enrollment_record, [:user_id])
+    create index(:enrollment_record, [:group_id])
+
+    create index(:group_session, [:group_id])
+    create index(:group_session, [:session_id])
+
+    create index(:user_session, [:user_id])
+    create index(:user_session, [:session_id])
+
+    create index(:session_occurrence, [:session_fk])
+
+    # Lookup / filter field indexes
+    create index(:user, [:phone])
+    create index(:user, [:date_of_birth])
+
+    create index(:student, [:student_id])
+    create index(:student, [:apaar_id])
+    create index(:student, [:grade_id])
+
+    create index(:session_occurrence, [:start_time])
+    create index(:session_occurrence, [:end_time])
+
+    create index(:resource_curriculum, [:resource_id])
+    create index(:resource_curriculum, [:subject_id])
+    create index(:resource_curriculum, [:grade_id])
+
+    create index(:resource_chapter, [:resource_id])
+    create index(:resource_chapter, [:chapter_id])
+
+    create index(:resource_topic, [:resource_id])
+    create index(:resource_topic, [:topic_id])
+
+    create index(:resource, [:type])
+    create index(:resource, [:subtype])
+
+    create index(:group, [:type])
+    create index(:group, [:child_id])
+
+    create index(:enrollment_record, [:group_type])
+    create index(:enrollment_record, [:is_current])
+    create index(:enrollment_record, [:academic_year])
+
+    create index(:school, [:code])
+    create index(:school, [:udise_code])
+    create index(:school, [:state])
+
+    create index(:batch, [:batch_id])
+  end
+end


### PR DESCRIPTION
### ADR
- https://www.notion.so/avantifellows/ADR-Adding-Indexes-to-Foreign-Keys-and-Frequently-Queried-Fields-257d19b3111c801e8a12f8d84e89c4d0#257d19b3111c80959a7cf729ef8e7089

### Description
- Added B-Tree indexes to improve join and filter performance across core tables.
- Covers FK relationships and high-traffic lookup fields per ADR.