### PR TITLE
Feat: Add chapter details to problem JSON response

### DIFF
--- a/lib/dbservice/resources.ex
+++ b/lib/dbservice/resources.ex
@@ -57,13 +57,16 @@ defmodule Dbservice.Resources do
              true <- test_resource.type == "test" do
           problem_ids = extract_problem_ids_from_test(test_resource.type_params)
 
-          # Query for all problems with those IDs, including ALL resource_curriculum data
+          # Query for all problems with those IDs, including ALL resource_curriculum data and chapter data
           problems =
             from(r in Resource,
               where: r.id in ^problem_ids and r.type == "problem",
               preload: [
                 # preload all curriculum mappings
                 :resource_curriculum,
+                # preload chapters via the many_to_many association
+                :chapter,
+                # keyword preload must come last in the list
                 problem_language: ^from(pl in ProblemLanguage, where: pl.lang_id == ^lang_id)
               ]
             )

--- a/lib/dbservice_web/json/resource_json.ex
+++ b/lib/dbservice_web/json/resource_json.ex
@@ -99,13 +99,19 @@ defmodule DbserviceWeb.ResourceJSON do
     # Get the base resource data using your existing pattern
     topic_id = Map.get(resource_topic, :topic_id, nil)
 
-    chapter_id =
-      Repo.one(
-        from rt in ResourceChapter,
-          where: rt.resource_id == ^resource.id,
-          select: rt.chapter_id,
-          limit: 1
-      )
+    # Get chapter information from preloaded data or fallback to query
+    chapter_data =
+      if Ecto.assoc_loaded?(resource.chapter) && length(resource.chapter) > 0 do
+        chapter = List.first(resource.chapter)
+
+        %{
+          chapter_id: chapter.id,
+          chapter_code: chapter.code,
+          chapter_name: chapter.name
+        }
+      else
+        %{chapter_id: nil, chapter_code: nil, chapter_name: nil}
+      end
 
     # Build the base resource representation
     base_map = %{
@@ -122,7 +128,9 @@ defmodule DbserviceWeb.ResourceJSON do
       learning_objective_ids: resource.learning_objective_ids,
       teacher_id: resource.teacher_id,
       topic_id: topic_id,
-      chapter_id: chapter_id,
+      chapter_id: chapter_data.chapter_id,
+      chapter_code: chapter_data.chapter_code,
+      chapter_name: chapter_data.chapter_name,
       cms_status: resource.cms_status
     }
 


### PR DESCRIPTION
### Description
- This update enhances the render_problem/1 function by including chapter information in the problem JSON output.
   - Extracts chapter_id, chapter_code, and chapter_name from the preloaded resource.chapter association.
   - Ensures chapter details are returned when available, otherwise falls back to nil values.
   - Keeps render_problem/1 focused on transforming already loaded data (no additional DB queries).